### PR TITLE
Support per-user session memory

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -26,15 +26,15 @@ app.use(cors({
 app.use(express.json());
 
 app.post('/chat', async (req, res) => {
-  const { message } = req.body;
+  const { message, userId } = req.body;
 
-  if (!message) {
-    return res.status(400).json({ error: "Mensaje requerido" });
+  if (!message || !userId) {
+    return res.status(400).json({ error: "Mensaje y userId requeridos" });
   }
 
   try {
     const startTime = Date.now();
-    const response = await reactHandler.manejarMensaje(message);
+    const response = await reactHandler.manejarMensaje(userId, message);
 
     // Simular tiempo de respuesta humano (1.5-3.5 segundos)
     const elapsed = Date.now() - startTime;

--- a/backend/src/modules/sessionMemory.js
+++ b/backend/src/modules/sessionMemory.js
@@ -1,0 +1,23 @@
+import fs from 'fs/promises';
+const MEMORY_DIR = './memory';
+
+export async function getSessionMemory(userId) {
+  try {
+    const data = await fs.readFile(`${MEMORY_DIR}/${userId}.json`, 'utf8');
+    return JSON.parse(data);
+  } catch (err) {
+    return [];
+  }
+}
+
+export async function updateSessionMemory(userId, history) {
+  try {
+    await fs.mkdir(MEMORY_DIR, { recursive: true });
+    await fs.writeFile(
+      `${MEMORY_DIR}/${userId}.json`,
+      JSON.stringify(history.slice(-10), null, 2)
+    );
+  } catch (err) {
+    console.error('Error updating session memory:', err);
+  }
+}


### PR DESCRIPTION
## Summary
- store chat history per user in new `sessionMemory` module
- pass `userId` from `/chat` route to `ReActHandler`
- fetch and save history inside `manejarMensaje`
- avoid storing conversation logs in memory

## Testing
- `node backend/src/index.js` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_684044e2bd208328a11e784deb97c6d5