### PR TITLE
Support multi-user sessions in chat endpoint

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -26,7 +26,11 @@ app.use(cors({
 app.use(express.json());
 
 app.post('/chat', async (req, res) => {
-  const { message } = req.body;
+  const { userId, message } = req.body;
+
+  if (!userId || typeof userId !== 'string') {
+    return res.status(400).json({ error: "userId requerido" });
+  }
 
   if (!message) {
     return res.status(400).json({ error: "Mensaje requerido" });
@@ -34,7 +38,7 @@ app.post('/chat', async (req, res) => {
 
   try {
     const startTime = Date.now();
-    const response = await reactHandler.manejarMensaje(message);
+    const response = await reactHandler.manejarMensaje(userId, message);
 
     // Simular tiempo de respuesta humano (1.5-3.5 segundos)
     const elapsed = Date.now() - startTime;

--- a/frontend/client.js
+++ b/frontend/client.js
@@ -1,0 +1,12 @@
+export async function sendMessage(userId, message) {
+  const res = await fetch('http://localhost:3000/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, message })
+  });
+  if (!res.ok) {
+    throw new Error(`Request failed: ${res.status}`);
+  }
+  return res.json();
+}
+


### PR DESCRIPTION
## Summary
- allow `/chat` to accept `{ userId, message }`
- store conversations per user in `ReActHandler`
- example `frontend/client.js` demonstrates new request format

## Testing
- `node --check backend/src/index.js`
- `node --check backend/src/modules/ReActHandler.js`
- `node --check frontend/client.js`
- `node backend/src/index.js` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_684044e79fe8832891b97fb11cf4a8f9