### PR TITLE
Add memory module test

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,6 +3,10 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "openai": "^4.103.0"
+    "openai": "^4.103.0",
+    "mongodb": "^6.5.0"
+  },
+  "scripts": {
+    "test-memory": "node testMemory.js"
   }
 }

--- a/backend/src/sessionMemory.js
+++ b/backend/src/sessionMemory.js
@@ -1,0 +1,36 @@
+require('dotenv').config();
+const { MongoClient } = require('mongodb');
+
+const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017';
+const dbName = process.env.DB_NAME || 'agentic';
+const collectionName = 'session_memory';
+
+let client;
+
+async function getCollection() {
+  if (!client) {
+    client = new MongoClient(uri, { useUnifiedTopology: true });
+    await client.connect();
+  }
+  return client.db(dbName).collection(collectionName);
+}
+
+async function getSessionMemory(userId) {
+  const col = await getCollection();
+  const doc = await col.findOne({ userId });
+  return doc ? doc.data : null;
+}
+
+async function updateSessionMemory(userId, data) {
+  const col = await getCollection();
+  await col.updateOne(
+    { userId },
+    { $set: { data } },
+    { upsert: true }
+  );
+}
+
+module.exports = {
+  getSessionMemory,
+  updateSessionMemory,
+};

--- a/backend/testMemory.js
+++ b/backend/testMemory.js
@@ -1,0 +1,23 @@
+// testMemory.js
+
+require('dotenv').config();
+const { getSessionMemory, updateSessionMemory } = require('./src/sessionMemory');
+
+(async () => {
+  const userId = 'test-user-001';
+
+  console.log('🧪 Guardando memoria de prueba...');
+  await updateSessionMemory(userId, {
+    historialMensajes: ['Hola', 'Quiero reservar'],
+    intenciones: ['reservar'],
+    fechasConsultadas: ['2025-06-15'],
+  });
+
+  console.log('✅ Memoria guardada. Leyendo...');
+  const data = await getSessionMemory(userId);
+
+  console.log('🧾 Resultado desde MongoDB:');
+  console.log(data);
+
+  process.exit();
+})();


### PR DESCRIPTION
## Summary
- store session data in MongoDB with a new `sessionMemory` module
- demo file `testMemory.js` to insert and read sample memory
- add `test-memory` npm script and MongoDB dependency

## Testing
- `npm run test-memory` *(fails: MongoDB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_683fb6813ddc8328b14ad865592bf63a