### PR TITLE
Add ReActHandler integration

### DIFF
--- a/backend/src/ReActHandler.js
+++ b/backend/src/ReActHandler.js
@@ -5,18 +5,21 @@ const callOpenAI = require('./modules/callOpenAI');
 const sessionMemory = new Map();
 
 module.exports = {
-    async processMessage(userMessage) {
-        // 1. Analizar intención
+    async processMessage(userId, userMessage) {
+        const history = sessionMemory.get(userId) || [];
+        history.push(userMessage);
+        if (history.length > 10) history.shift();
+        sessionMemory.set(userId, history);
+
         const { intencion, emocion } = detectarIntencionEmocion(userMessage);
-        
-        // 2. Generar prompt
+
         const prompt = `
+        Historial: ${history.join('\n')}
         [Intención: ${intencion}]
         [Emoción: ${emocion}]
         Usuario: ${userMessage}
         `;
 
-        // 3. Llamar a OpenAI
         return await callOpenAI(prompt);
     }
 };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,32 +1,27 @@
 const express = require('express');
 const cors = require('cors');
+const ReActHandler = require('./ReActHandler');
 
 const app = express();
 
-const corsOptions = {
-  origin: ["http://localhost:3002", "https://agentic-frontend.onrender.com"],
-  methods: ["GET", "POST", "OPTIONS"],
-  allowedHeaders: ["Content-Type", "Authorization"],
-  credentials: true
-};
-
-// ✅ CORS aplicado globalmente
-app.use(cors(corsOptions));
-
-// ✅ Corrección aquí: manejamos OPTIONS manualmente
-app.options('*', (req, res) => {
-  res.sendStatus(204);
-});
+// CORS abierto para cualquier origen
+app.use(cors());
 
 app.use(express.json());
 
 app.post('/message', async (req, res) => {
   console.log("📩 Se recibió una solicitud POST a /message");
 
-  const message = req.body.message || '';
-  console.log("🧾 Contenido del mensaje recibido:", message);
+  const { userId, message = '' } = req.body;
+  console.log("🧾 Contenido del mensaje recibido:", { userId, message });
 
-  res.json({ reply: `Recibido: ${message}` });
+  try {
+    const response = await ReActHandler.processMessage(userId, message);
+    res.json({ response });
+  } catch (error) {
+    console.error('❌ Error procesando mensaje:', error);
+    res.status(500).json({ error: 'Error procesando mensaje' });
+  }
 });
 
 


### PR DESCRIPTION
## Summary
- wire ReActHandler into the API
- accept `userId` and `message` from the request body
- route to `ReActHandler.processMessage`
- loosen CORS configuration

## Testing
- `npm install --prefix backend`
- `node backend/src/index.js` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f5a0696c083289b2d9248976874f1