### PR TITLE
Fix ChatBot backend response field

### DIFF
--- a/frontend/src/components/ChatBot.jsx
+++ b/frontend/src/components/ChatBot.jsx
@@ -20,7 +20,7 @@ const ChatBot = () => {
       setMessages((prev) => [
         ...prev,
         { text: input, isUser: true },
-        { text: data.response, isUser: false },
+        { text: data.reply, isUser: false },
       ]);
 
       setInput("");


### PR DESCRIPTION
## Summary
- use `data.reply` instead of `data.response` when reading backend reply

## Testing
- `npm test --prefix frontend` *(fails: react-scripts Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_683f52f354dc8328a14da27c0360127e