### PR TITLE
Implement session history for ReActHandler

### DIFF
--- a/backend/src/ReActHandler.js
+++ b/backend/src/ReActHandler.js
@@ -2,21 +2,59 @@ const detectarIntencionEmocion = require('./modules/detectarIntencionEmocion');
 const callOpenAI = require('./modules/callOpenAI');
 
 // Memoria temporal
+// Memoria de conversación en memoria para cada usuario
 const sessionMemory = new Map();
 
+// Configuración de límites
+const MAX_HISTORY = 20; // número máximo de mensajes a guardar por usuario
+const SESSION_TTL = 1000 * 60 * 60; // 1 hora en milisegundos
+
+function cleanupSessions() {
+    const now = Date.now();
+    for (const [userId, session] of sessionMemory) {
+        if (now - session.lastUpdated > SESSION_TTL) {
+            sessionMemory.delete(userId);
+        }
+    }
+}
+
 module.exports = {
-    async processMessage(userMessage) {
-        // 1. Analizar intención
+    /**
+     * Procesa un mensaje de un usuario manteniendo el historial de la sesión.
+     * @param {string} userId identificador único del usuario o token de sesión
+     * @param {string} userMessage mensaje enviado por el usuario
+     */
+    async processMessage(userId, userMessage) {
+        cleanupSessions();
+
+        let session = sessionMemory.get(userId);
+        if (!session) {
+            session = { messages: [], lastUpdated: Date.now() };
+            sessionMemory.set(userId, session);
+        }
+
+        session.messages.push({ role: 'user', content: userMessage, timestamp: Date.now() });
+        session.lastUpdated = Date.now();
+
+        // 1. Analizar intención y emoción del mensaje actual
         const { intencion, emocion } = detectarIntencionEmocion(userMessage);
-        
-        // 2. Generar prompt
+
+        // 2. Generar historial para el prompt
+        const historyText = session.messages.map(m => `${m.role === 'user' ? 'Usuario' : 'Asistente'}: ${m.content}`).join('\n');
         const prompt = `
         [Intención: ${intencion}]
         [Emoción: ${emocion}]
-        Usuario: ${userMessage}
+        ${historyText}
         `;
 
         // 3. Llamar a OpenAI
-        return await callOpenAI(prompt);
+        const response = await callOpenAI(prompt);
+
+        session.messages.push({ role: 'assistant', content: response, timestamp: Date.now() });
+        if (session.messages.length > MAX_HISTORY) {
+            session.messages.splice(0, session.messages.length - MAX_HISTORY);
+        }
+
+        return response;
     }
 };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');
+const { processMessage } = require('./ReActHandler');
 
 const app = express();
 
@@ -24,9 +25,16 @@ app.post('/message', async (req, res) => {
   console.log("📩 Se recibió una solicitud POST a /message");
 
   const message = req.body.message || '';
+  const userId = req.body.userId || req.ip;
   console.log("🧾 Contenido del mensaje recibido:", message);
 
-  res.json({ reply: `Recibido: ${message}` });
+  try {
+    const reply = await processMessage(userId, message);
+    res.json({ reply });
+  } catch (err) {
+    console.error('❌ Error al procesar el mensaje', err);
+    res.status(500).json({ reply: 'Hubo un error procesando el mensaje' });
+  }
 });
 
 


### PR DESCRIPTION
## Summary
- track chat history per user in `ReActHandler`
- attach that history to prompts sent to OpenAI
- prune old sessions and limit stored history
- use the new handler from the `/message` route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f554a5ce883289682cc809d11c37f