### PR TITLE
Implement session memory for backend

### DIFF
--- a/backend/src/ReActHandler.js
+++ b/backend/src/ReActHandler.js
@@ -1,22 +1,32 @@
 const detectarIntencionEmocion = require('./modules/detectarIntencionEmocion');
 const callOpenAI = require('./modules/callOpenAI');
-
-// Memoria temporal
-const sessionMemory = new Map();
+const { getMemory, updateMemory } = require('./sessionMemory');
 
 module.exports = {
-    async processMessage(userMessage) {
+    async processMessage(userId, userMessage) {
         // 1. Analizar intención
         const { intencion, emocion } = detectarIntencionEmocion(userMessage);
-        
+
         // 2. Generar prompt
+        const history = getMemory(userId)
+            .map(m => `${m.role === 'user' ? 'Usuario' : 'Asistente'}: ${m.content}`)
+            .join('\n');
         const prompt = `
+        ${history}
         [Intención: ${intencion}]
         [Emoción: ${emocion}]
         Usuario: ${userMessage}
         `;
 
+        // Registrar en memoria
+        updateMemory(userId, { role: 'user', content: userMessage });
+
         // 3. Llamar a OpenAI
-        return await callOpenAI(prompt);
+        const reply = await callOpenAI(prompt);
+
+        // Guardar respuesta en memoria
+        updateMemory(userId, { role: 'assistant', content: reply });
+
+        return reply;
     }
 };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');
+const ReActHandler = require('./ReActHandler');
 
 const app = express();
 
@@ -24,9 +25,16 @@ app.post('/message', async (req, res) => {
   console.log("📩 Se recibió una solicitud POST a /message");
 
   const message = req.body.message || '';
+  const userId = req.body.userId || 'default';
   console.log("🧾 Contenido del mensaje recibido:", message);
 
-  res.json({ reply: `Recibido: ${message}` });
+  try {
+    const reply = await ReActHandler.processMessage(userId, message);
+    res.json({ reply });
+  } catch (err) {
+    console.error('❌ Error procesando mensaje:', err);
+    res.status(500).json({ reply: 'Ocurrió un error.' });
+  }
 });
 
 

--- a/backend/src/sessionMemory.js
+++ b/backend/src/sessionMemory.js
@@ -1,0 +1,19 @@
+const memory = new Map();
+
+function getMemory(userId) {
+  if (!memory.has(userId)) {
+    memory.set(userId, []);
+  }
+  return memory.get(userId);
+}
+
+function updateMemory(userId, data) {
+  const userMemory = getMemory(userId);
+  userMemory.push(data);
+}
+
+module.exports = {
+  memory,
+  getMemory,
+  updateMemory,
+};


### PR DESCRIPTION
## Summary
- add simple in-memory session store
- store/retrieve short-term conversation data in ReActHandler
- route messages through new handler in the API

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f5a0406448328bed330b955478cf3