### PR TITLE
Implement session memory handling

### DIFF
--- a/backend/src/modules/sessionMemory.js
+++ b/backend/src/modules/sessionMemory.js
@@ -1,0 +1,16 @@
+const sessions = new Map();
+
+function getMemory(userId) {
+  if (!sessions.has(userId)) {
+    sessions.set(userId, []);
+  }
+  return sessions.get(userId);
+}
+
+function addExchange(userId, userMessage, assistantMessage) {
+  const memory = getMemory(userId);
+  memory.push({ role: 'user', content: userMessage });
+  memory.push({ role: 'assistant', content: assistantMessage });
+}
+
+module.exports = { getMemory, addExchange };


### PR DESCRIPTION
## Summary
- add `sessionMemory` module for per-user chat history
- enhance `ReActHandler` to use session memory and new signature

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_683f5a06570083288da7a940608f5454