### PR TITLE
Ensure estrategiaConversacional uses CommonJS

### DIFF
--- a/backend/src/modules/ReActHandler.js
+++ b/backend/src/modules/ReActHandler.js
@@ -9,7 +9,8 @@ import {
   actualizarUltimaHora,
   getContextoConversacion
 } from './sessionMemory.js';
-import { decidirEstrategia } from './estrategiaConversacional.js';
+import estrategia from './estrategiaConversacional.js';
+const { decidirEstrategia } = estrategia;
 
 export class ReActHandler {
   constructor() {

--- a/backend/src/modules/estrategiaConversacional.js
+++ b/backend/src/modules/estrategiaConversacional.js
@@ -1,4 +1,4 @@
-export function decidirEstrategia(intencion, emocion, contexto = {}) {
+function decidirEstrategia(intencion, emocion, contexto = {}) {
   const ahora = Date.now();
   const ultima = contexto.ultimaRespuestaHora
     ? new Date(contexto.ultimaRespuestaHora).getTime()
@@ -86,3 +86,5 @@ export function decidirEstrategia(intencion, emocion, contexto = {}) {
       return null;
   }
 }
+
+module.exports = { decidirEstrategia };


### PR DESCRIPTION
## Summary
- export `decidirEstrategia` using `module.exports`
- adjust `ReActHandler` to consume the CommonJS module

## Testing
- `node -e "require('./backend/src/modules/estrategiaConversacional.js');"`

------
https://chatgpt.com/codex/tasks/task_e_684914910b68832886d8d139c3b0b602