### PR TITLE
Move desaparicion detection to own module

### DIFF
--- a/backend/src/modules/detectorDesaparicion.js
+++ b/backend/src/modules/detectorDesaparicion.js
@@ -1,0 +1,20 @@
+import mongoose from 'mongoose';
+
+export async function detectarDesaparicion(userId, minutos = 5) {
+  try {
+    const Session = mongoose.model('Session');
+    const session = await Session.findOne({ userId }).exec();
+    if (!session || !session.ultimaRespuestaHora) return false;
+    const diffMin =
+      (Date.now() - new Date(session.ultimaRespuestaHora).getTime()) / 60000;
+    const desaparecido = diffMin > minutos;
+    if (session.desaparecido !== desaparecido) {
+      session.desaparecido = desaparecido;
+      await session.save();
+    }
+    return desaparecido;
+  } catch (err) {
+    console.error('Error detectando desaparicion:', err);
+    return false;
+  }
+}

--- a/backend/src/modules/sessionMemory.js
+++ b/backend/src/modules/sessionMemory.js
@@ -83,20 +83,4 @@ export async function actualizarUltimaHora(userId, timestamp = new Date()) {
   }
 }
 
-export async function detectarDesaparicion(userId, minutos = 5) {
-  try {
-    const session = await Session.findOne({ userId }).exec();
-    if (!session || !session.ultimaRespuestaHora) return false;
-    const diffMin =
-      (Date.now() - new Date(session.ultimaRespuestaHora).getTime()) / 60000;
-    const desaparecido = diffMin > minutos;
-    if (session.desaparecido !== desaparecido) {
-      session.desaparecido = desaparecido;
-      await session.save();
-    }
-    return desaparecido;
-  } catch (err) {
-    console.error('Error detectando desaparicion:', err);
-    return false;
-  }
-}
+export { detectarDesaparicion } from './detectorDesaparicion.js';


### PR DESCRIPTION
## Summary
- extract desaparicion detection logic into its own file
- re-export detectarDesaparicion from `sessionMemory.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684990a8df608328ba34f6795d4cb8ee