### PR TITLE
Add disappearance check in ReActHandler

### DIFF
--- a/backend/src/modules/ReActHandler.js
+++ b/backend/src/modules/ReActHandler.js
@@ -7,7 +7,8 @@ import {
   updateSessionMemory,
   registrarMensaje,
   actualizarUltimaHora,
-  getContextoConversacion
+  getContextoConversacion,
+  detectarDesaparicion
 } from './sessionMemory.js';
 import estrategia from './estrategiaConversacional.js';
 const { decidirEstrategia } = estrategia;
@@ -18,8 +19,13 @@ export class ReActHandler {
   }
 
   async manejarMensaje(userId, userMessage) {
+    const desaparicionInfo = await detectarDesaparicion(userId);
     const historial = await getSessionMemory(userId);
     const contexto = await getContextoConversacion(userId);
+    if (desaparicionInfo && desaparicionInfo.necesitaSeguimiento) {
+      console.log(`↪ Desaparición detectada para ${userId}`);
+      contexto.seguimiento = true;
+    }
     const analisis = await detectarIntencionEmocion(userMessage, historial);
 
     const estrategia = decidirEstrategia(


### PR DESCRIPTION
## Summary
- monitor inactive users before analyzing messages
- mark conversation for follow‑up when disappearance is detected
- log disappearance events

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684990ad65bc8328a8c7c3db913710fb