### PR TITLE
Use named export for decidirEstrategia

### DIFF
--- a/backend/src/modules/ReActHandler.js
+++ b/backend/src/modules/ReActHandler.js
@@ -9,8 +9,7 @@ import {
   actualizarUltimaHora,
   getContextoConversacion
 } from './sessionMemory.js';
-import estrategia from './estrategiaConversacional.js';
-const { decidirEstrategia } = estrategia;
+import { decidirEstrategia } from './estrategiaConversacional.js';
 
 export class ReActHandler {
   constructor() {

--- a/backend/src/modules/estrategiaConversacional.js
+++ b/backend/src/modules/estrategiaConversacional.js
@@ -87,4 +87,4 @@ function decidirEstrategia(intencion, emocion, contexto = {}) {
   }
 }
 
-module.exports = { decidirEstrategia };
+export { decidirEstrategia };


### PR DESCRIPTION
## Summary
- convert `decidirEstrategia` module to ES module export
- update `ReActHandler` to use named import

## Testing
- `npm test --prefix backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684990b8ff0083289eb64c78cb64a4b8