### PR TITLE
Add payment link generator module

### DIFF
--- a/backend/src/modules/generarLinkDePago.js
+++ b/backend/src/modules/generarLinkDePago.js
@@ -1,0 +1,10 @@
+export async function generarLinkDePago(fecha, personas, monto) {
+  // Placeholder implementation; integrate Stripe API here in the future.
+  const baseUrl = 'https://pay.stripe.com/test';
+  const query = new URLSearchParams({
+    fecha,
+    personas: String(personas),
+    monto: String(monto)
+  }).toString();
+  return `${baseUrl}?${query}`;
+}


### PR DESCRIPTION
## Summary
- create `generarLinkDePago` utility
- placeholder implementation returns fake Stripe URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a316ddcc8328aad5752245d5b50d