### PR TITLE
Add reserva tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ node_modules/
 *.log
 
 # Test JavaScript files
-*.test.js
 
 # macOS system files
 .DS_Store

--- a/backend/src/modules/reserva.js
+++ b/backend/src/modules/reserva.js
@@ -1,0 +1,14 @@
+export async function consultarDisponibilidad(fecha, dataSource) {
+  const reservas = await Promise.resolve(dataSource.getReservas(fecha));
+  const capacidadTotal = Object.values(dataSource.capacidadPorDomo || {}).reduce((a,b) => a + b, 0);
+  const capacidad = capacidadTotal || dataSource.capacidad || 0;
+  return reservas < capacidad;
+}
+
+export function generarLinkDePago(baseUrl, idReserva) {
+  const url = new URL(baseUrl);
+  if (idReserva) {
+    url.searchParams.set('id', idReserva);
+  }
+  return url.toString();
+}

--- a/backend/tests/consultarDisponibilidad.test.js
+++ b/backend/tests/consultarDisponibilidad.test.js
@@ -1,0 +1,21 @@
+import { jest } from "@jest/globals";
+import { consultarDisponibilidad } from '../src/modules/reserva.js';
+
+describe('consultarDisponibilidad', () => {
+  const mockData = {
+    capacidad: 2,
+    getReservas: jest.fn()
+  };
+
+  test('returns true when less reservations than capacity', async () => {
+    mockData.getReservas.mockResolvedValueOnce(1);
+    const result = await consultarDisponibilidad('2025-01-01', mockData);
+    expect(result).toBe(true);
+  });
+
+  test('returns false when reservations meet capacity', async () => {
+    mockData.getReservas.mockResolvedValueOnce(2);
+    const result = await consultarDisponibilidad('2025-01-02', mockData);
+    expect(result).toBe(false);
+  });
+});

--- a/backend/tests/generarLinkDePago.test.js
+++ b/backend/tests/generarLinkDePago.test.js
@@ -1,0 +1,13 @@
+import { generarLinkDePago } from '../src/modules/reserva.js';
+
+describe('generarLinkDePago', () => {
+  test('returns URL with reservation id', () => {
+    const url = generarLinkDePago('https://pago.com/checkout', 'abc123');
+    expect(url).toBe('https://pago.com/checkout?id=abc123');
+  });
+
+  test('works without id', () => {
+    const url = generarLinkDePago('https://pago.com/checkout');
+    expect(url).toBe('https://pago.com/checkout');
+  });
+});


### PR DESCRIPTION
## Summary
- allow tracking test files
- add reserva module with consultarDisponibilidad and generarLinkDePago
- test consultarDisponibilidad for available/unavailable dates
- test generarLinkDePago output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a318cd08832887951baca09b6cb2