### PR TITLE
Implementar envío de correo tras pago

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "express": "^4.18.2",
         "google-spreadsheet": "^3.3.0",
         "mongoose": "^8.15.1",
+        "nodemailer": "^6.9.5",
         "openai": "^4.0.0",
         "xlsx": "^0.18.5"
       },
@@ -4753,6 +4754,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.10",

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "mongoose": "^8.15.1",
     "openai": "^4.0.0",
     "google-spreadsheet": "^3.3.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "nodemailer": "^6.9.5"
   },
   "devDependencies": {
     "jest": "^30.0.0",

--- a/backend/src/modules/ReActHandler.js
+++ b/backend/src/modules/ReActHandler.js
@@ -29,6 +29,7 @@ export class ReActHandler {
       contexto.seguimiento = true;
     }
     const analisis = await detectarIntencionEmocion(userMessage, historial);
+    contexto.datosReserva = { ...(contexto.datosReserva || {}), ...(analisis.detalles || {}) };
 
     let disponibilidadInfo = '';
     let linkPago = '';
@@ -45,7 +46,7 @@ export class ReActHandler {
       }
     }
 
-    const estrategia = decidirEstrategia(
+    const estrategia = await decidirEstrategia(
       analisis.intencion,
       analisis.emocion_principal,
       contexto

--- a/backend/src/modules/enviarCorreoConfirmacion.js
+++ b/backend/src/modules/enviarCorreoConfirmacion.js
@@ -1,0 +1,50 @@
+import nodemailer from 'nodemailer';
+import { ALMA_CONFIG } from '../config/almaConfig.js';
+
+export async function enviarCorreoConfirmacion({
+  email,
+  nombre = '',
+  fecha = '',
+  detallesLlegada = ''
+}) {
+  if (!email) {
+    console.error('No se proporcionó un email para enviar la confirmación');
+    return;
+  }
+
+  const plantilla =
+    ALMA_CONFIG.PLANTILLA_CORREO_CONFIRMACION ||
+    `Hola {{nombre}},\n\nTu reserva para {{fecha}} ha sido confirmada.\n{{detalles}}\n\n${ALMA_CONFIG.NOMBRE_AGENTE} te da la bienvenida a ${ALMA_CONFIG.NOMBRE_NEGOCIO}.`;
+
+  const mensaje = plantilla
+    .replace('{{nombre}}', nombre)
+    .replace('{{fecha}}', fecha)
+    .replace('{{detalles}}', detallesLlegada);
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT) || 587,
+    secure: false,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS
+    }
+  });
+
+  try {
+    await transporter.sendMail({
+      from: ALMA_CONFIG.CORREO_ORIGEN || process.env.SMTP_USER,
+      to: email,
+      subject: `Confirmación de reserva - ${ALMA_CONFIG.NOMBRE_NEGOCIO}`,
+      text: mensaje
+    });
+    console.log(`✉️  Correo de confirmación enviado a ${email}`);
+  } catch (err) {
+    console.error('Error enviando correo de confirmación:', err);
+  }
+}
+
+export function bloquearFecha() {
+  // Función pendiente de implementación
+  console.log('bloquearFecha() aún no implementada');
+}

--- a/backend/tests/consultarDisponibilidad.test.js
+++ b/backend/tests/consultarDisponibilidad.test.js
@@ -1,5 +1,4 @@
-<<<<<<< HEAD
-import { jest } from "@jest/globals";
+import { jest } from '@jest/globals';
 import { consultarDisponibilidad } from '../src/modules/reserva.js';
 
 describe('consultarDisponibilidad', () => {
@@ -19,22 +18,5 @@ describe('consultarDisponibilidad', () => {
     const result = await consultarDisponibilidad('2025-01-02', mockData);
     expect(result).toBe(false);
   });
-=======
-import { consultarDisponibilidad } from '../src/modules/consultarDisponibilidad.js';
-
-beforeAll(() => {
-  process.env.GOOGLE_SHEET_ID = '';
-  process.env.GOOGLE_CLIENT_EMAIL = '';
-  process.env.GOOGLE_PRIVATE_KEY = '';
 });
 
-test('returns true when date is available', async () => {
-  const result = await consultarDisponibilidad('2024-07-01');
-  expect(result.disponible).toBe(true);
-});
-
-test('returns false when date is not available', async () => {
-  const result = await consultarDisponibilidad('2024-07-02');
-  expect(result.disponible).toBe(false);
->>>>>>> main
-});

--- a/backend/tests/enviarCorreoConfirmacion.test.js
+++ b/backend/tests/enviarCorreoConfirmacion.test.js
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+import nodemailer from 'nodemailer';
+import { enviarCorreoConfirmacion } from '../src/modules/enviarCorreoConfirmacion.js';
+
+describe('enviarCorreoConfirmacion', () => {
+  test('envia correo utilizando nodemailer', async () => {
+    const sendMail = jest.fn().mockResolvedValue(true);
+    nodemailer.createTransport = jest.fn(() => ({ sendMail }));
+
+    await enviarCorreoConfirmacion({
+      email: 'test@example.com',
+      nombre: 'Juan',
+      fecha: '2024-08-01',
+      detallesLlegada: 'Llegada 3pm'
+    });
+
+    expect(sendMail).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- arreglar test de disponibilidad después de conflicto
- añadir módulo **enviarCorreoConfirmacion** para enviar mensajes vía SMTP
- detectar pago en la estrategia conversacional y lanzar el correo
- registrar datos de reserva en el manejador y actualizar llamada
- cubrir el nuevo módulo con pruebas

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6849b98902a0832895aa8e5de3080fdf