### PR TITLE
Add multi-agent manager with logging

### DIFF
--- a/backend/src/modules/GroupChatManager.js
+++ b/backend/src/modules/GroupChatManager.js
@@ -1,0 +1,57 @@
+import { registrarInteraccion } from './registrarInteraccion.js';
+
+export class GroupChatManager {
+  constructor() {
+    this.planner = new AlmaPlanner();
+    this.engineer = new AlmaEngineer();
+    this.executor = new AlmaExecutor();
+    this.writer = new AlmaWriter();
+    this.admin = new AlmaAdmin();
+  }
+
+  async procesarMensaje(mensaje) {
+    const plan = this.planner.planear(mensaje);
+    const funcion = this.engineer.generarFuncion(plan);
+    const resultado = this.executor.ejecutar(funcion);
+    const respuesta = this.writer.redactar(resultado);
+    return this.admin.revisar(respuesta);
+  }
+}
+
+class AlmaPlanner {
+  planear(intencion) {
+    if (typeof intencion === 'string' && intencion.length > 20) {
+      registrarInteraccion('intencionCompleja', { mensaje: intencion });
+    }
+    return `plan(${intencion})`;
+  }
+}
+
+class AlmaEngineer {
+  generarFuncion(descripcion) {
+    registrarInteraccion('funcionGenerada', { descripcion });
+    return () => `ejecutando ${descripcion}`;
+  }
+}
+
+class AlmaExecutor {
+  ejecutar(tareaFn) {
+    const resultado = tareaFn();
+    registrarInteraccion('tareaEjecutada', { resultado });
+    return resultado;
+  }
+}
+
+class AlmaWriter {
+  redactar(texto) {
+    registrarInteraccion('contenidoRedactado', { texto });
+    return `AlmaWriter: ${texto}`;
+  }
+}
+
+class AlmaAdmin {
+  revisar(tarea) {
+    registrarInteraccion('revisionTarea', { tarea });
+    return `AlmaAdmin revisó: ${tarea}`;
+  }
+}

--- a/backend/src/modules/registrarInteraccion.js
+++ b/backend/src/modules/registrarInteraccion.js
@@ -1,0 +1,5 @@
+export function registrarInteraccion(tipo, datos = {}) {
+  const serializado = JSON.stringify(datos);
+  console.log(`[🧠 Interacción] ${tipo} → ${serializado}`);
+  // TODO: Integrar con base de datos para almacenar interacciones
+}

--- a/backend/tests/registrarInteraccion.test.js
+++ b/backend/tests/registrarInteraccion.test.js
@@ -1,0 +1,11 @@
+import { jest } from "@jest/globals";
+import { registrarInteraccion } from '../src/modules/registrarInteraccion.js';
+
+describe('registrarInteraccion', () => {
+  test('logea interaccion', () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    registrarInteraccion('test', { hola: 'mundo' });
+    expect(spy).toHaveBeenCalledWith('[🧠 Interacción] test → {"hola":"mundo"}');
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add `registrarInteraccion` util for standardized logging
- create `GroupChatManager` with simulated Alma agents calling the logger
- include jest test for logger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849bde27ccc832889446cd24198387f