### PR TITLE
Add Stripe payment module and test

### DIFF
--- a/backend/src/modules/procesarPagoStripe.js
+++ b/backend/src/modules/procesarPagoStripe.js
@@ -1,0 +1,8 @@
+export function procesarPagoStripe({ fecha, personas, monto }) {
+  const link = 'https://pay.stripe.com/test';
+  const mensaje = 'Pago pendiente';
+  const reservaId = 'reserva-demo';
+  console.log(`[💳 Pago] Link generado para reserva del ${fecha} → ${link}`);
+  // TODO: integrar Stripe API aquí para futura integración real.
+  return { link, mensaje, reservaId };
+}

--- a/backend/tests/procesarPagoStripe.test.js
+++ b/backend/tests/procesarPagoStripe.test.js
@@ -1,0 +1,16 @@
+import { jest } from '@jest/globals';
+import { procesarPagoStripe } from '../src/modules/procesarPagoStripe.js';
+
+describe('procesarPagoStripe', () => {
+  test('retorna objeto esperado y logea link', () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const result = procesarPagoStripe({ fecha: '2024-01-01', personas: 2, monto: 100 });
+    expect(result).toEqual({
+      link: 'https://pay.stripe.com/test',
+      mensaje: 'Pago pendiente',
+      reservaId: 'reserva-demo'
+    });
+    expect(spy).toHaveBeenCalledWith('[💳 Pago] Link generado para reserva del 2024-01-01 → https://pay.stripe.com/test');
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add `procesarPagoStripe` module for placeholder Stripe integration
- log link generation and return structured data
- test new module behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c187b5d48328b767d5576fc1c553