### PR TITLE
Add MongoDB session narrative memory

### DIFF
--- a/backend/src/modules/moduladorNarrativo.js
+++ b/backend/src/modules/moduladorNarrativo.js
@@ -1,0 +1,21 @@
+export function ajustarPrompt(prompt, mensajes = []) {
+  const saludosRegex = /(hola|¿como estas\??|buen[oa]s)/i;
+  const modismosRegex = /(pura vida|que chiva)/i;
+
+  const haSaludado = mensajes.some(m => m.de === 'alma' && saludosRegex.test(m.texto));
+  const haUsadoModismo = mensajes.some(m => m.de === 'alma' && modismosRegex.test(m.texto));
+
+  let instrucciones = [];
+  if (haSaludado) {
+    instrucciones.push('Evita repetir saludos al usuario.');
+  }
+  if (haUsadoModismo) {
+    instrucciones.push('No repitas modismos ticos como "¡Pura vida!" o "¡Qué chiva!".');
+  }
+
+  if (instrucciones.length > 0) {
+    return `${prompt}\nConsideraciones adicionales: ${instrucciones.join(' ')}`;
+  }
+  return prompt;
+}
+


### PR DESCRIPTION
## Summary
- extend session memory to persist chat messages for each user
- add helper to trim message history and store last update timestamp
- create narrative prompt adjustment to avoid repeat greetings
- integrate new narrative memory in `ReActHandler`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ef2a54a1c8328910d186851b55b62